### PR TITLE
Add name per vPC group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ module "aci_vpc_group" {
   count = lookup(local.modules, "aci_vpc_group", true) == false ? 0 : 1
   mode  = lookup(lookup(local.node_policies, "vpc_groups", {}), "mode", local.defaults.apic.node_policies.vpc_groups.mode)
   groups = [for group in lookup(lookup(local.node_policies, "vpc_groups", {}), "groups", []) : {
-    name     = replace("${group.id}:${group.switch_1}:${group.switch_2}", "/^(?P<id>.+):(?P<switch1_id>.+):(?P<switch2_id>.+)$/", replace(replace(replace(lookup(local.access_policies, "vpc_group_name", local.defaults.apic.access_policies.vpc_group_name), "\\g<id>", "$id"), "\\g<switch1_id>", "$switch1_id"), "\\g<switch2_id>", "$switch2_id"))
+    name     = lookup(group, "name", replace("${group.id}:${group.switch_1}:${group.switch_2}", "/^(?P<id>.+):(?P<switch1_id>.+):(?P<switch2_id>.+)$/", replace(replace(replace(lookup(local.access_policies, "vpc_group_name", local.defaults.apic.access_policies.vpc_group_name), "\\g<id>", "$id"), "\\g<switch1_id>", "$switch1_id"), "\\g<switch2_id>", "$switch2_id")))
     id       = group.id
     policy   = lookup(group, "policy", "")
     switch_1 = group.switch_1


### PR DESCRIPTION
Customer would like to configure names per vPC groups. Example:

````
---
apic:
  node_policies:
    vpc_groups:
      groups:
        - id: 1
          name: VPC_101_102
          switch_1: 101
          switch_2: 102
````
Currently this module ignores the group-specific `name` variable, and derives the name from the access_policies `vpc_group_name` attribute.

This PR adds support for `name` per vPC group, and defaults to the `vpc_group_name` only if the name is not given.